### PR TITLE
BAQE-2097 - Update version.kie and version.kogito to 7.59.0.Final and…

### DIFF
--- a/kie-assets-library-support/pom.xml
+++ b/kie-assets-library-support/pom.xml
@@ -21,7 +21,7 @@
         <maven.compiler.target>11</maven.compiler.target>
         <support.basedir>${main.basedir}/kie-assets-library-support</support.basedir>
         <quarkus.archetype.artifactId>kogito-quarkus-archetype</quarkus.archetype.artifactId>
-        <springboot.archetype.artifactId>kogito-springboot-archetype</springboot.archetype.artifactId>
+        <springboot.archetype.artifactId>kogito-spring-boot-archetype</springboot.archetype.artifactId>
     </properties>
 
     <dependencies>
@@ -59,7 +59,7 @@
                                 <archetype>
                                     <groupId>org.kie.kogito</groupId>
                                     <artifactId>${quarkus.archetype.artifactId}</artifactId>
-                                    <version>${version.kogito}</version>
+                                    <version>${version.kogito.quarkus}</version>
                                 </archetype>
                                 <delete-resources>
                                     <resource>
@@ -86,7 +86,7 @@
                                             <dependency>
                                                 <groupId>org.kie.kogito</groupId>
                                                 <artifactId>kogito-scenario-simulation</artifactId>
-                                                <version>${version.kogito}</version>
+                                                <version>${version.kogito.quarkus}</version>
                                                 <scope>test</scope>
                                             </dependency>
                                         </dependencies>
@@ -199,9 +199,8 @@
                     <name>productized</name>
                 </property>
             </activation>
-            <properties>
+            <properties> <!-- Spring Boot now uses the same archetype -->
                 <quarkus.archetype.artifactId>kogito-quarkus-dm-archetype</quarkus.archetype.artifactId>
-                <springboot.archetype.artifactId>kogito-springboot-dm-archetype</springboot.archetype.artifactId>
             </properties>
         </profile>
     </profiles>

--- a/kie-assets-plugin/src/it/active-combination-it/pom.xml
+++ b/kie-assets-plugin/src/it/active-combination-it/pom.xml
@@ -61,7 +61,7 @@
                             <archetype>
                                 <groupId>org.kie.kogito</groupId>
                                 <artifactId>kogito-quarkus-archetype</artifactId>
-                                <version>1.5.0.Final</version>
+                                <version>@version.kogito.quarkus@</version>
                             </archetype>
                             <delete-resources>
                                 <resource>
@@ -106,8 +106,8 @@
                             <id>springboot</id>
                             <archetype>
                                 <groupId>org.kie.kogito</groupId>
-                                <artifactId>kogito-springboot-archetype</artifactId>
-                                <version>1.5.0.Final</version>
+                                <artifactId>kogito-spring-boot-archetype</artifactId>
+                                <version>@version.kogito@</version>
                             </archetype>
                             <delete-resources>
                                 <resource>
@@ -146,7 +146,7 @@
                             <archetype>
                                 <groupId>org.kie</groupId>
                                 <artifactId>kie-kjar-archetype</artifactId>
-                                <version>7.52.0.Final</version>
+                                <version>@version.kie@</version>
                             </archetype>
                             <delete-resources>
                                 <resource>

--- a/kie-assets-plugin/src/it/active-combination-negate-it/pom.xml
+++ b/kie-assets-plugin/src/it/active-combination-negate-it/pom.xml
@@ -61,7 +61,7 @@
                             <archetype>
                                 <groupId>org.kie.kogito</groupId>
                                 <artifactId>kogito-quarkus-archetype</artifactId>
-                                <version>1.5.0.Final</version>
+                                <version>@version.kogito.quarkus@</version>
                             </archetype>
                             <delete-resources>
                                 <resource>
@@ -106,8 +106,8 @@
                             <id>springboot</id>
                             <archetype>
                                 <groupId>org.kie.kogito</groupId>
-                                <artifactId>kogito-springboot-archetype</artifactId>
-                                <version>1.5.0.Final</version>
+                                <artifactId>kogito-spring-boot-archetype</artifactId>
+                                <version>@version.kogito@</version>
                             </archetype>
                             <delete-resources>
                                 <resource>
@@ -146,7 +146,7 @@
                             <archetype>
                                 <groupId>org.kie</groupId>
                                 <artifactId>kie-kjar-archetype</artifactId>
-                                <version>7.52.0.Final</version>
+                                <version>@version.kie@</version>
                             </archetype>
                             <delete-resources>
                                 <resource>

--- a/kie-assets-plugin/src/it/active-definition-id-it/pom.xml
+++ b/kie-assets-plugin/src/it/active-definition-id-it/pom.xml
@@ -62,7 +62,7 @@
                             <archetype>
                                 <groupId>org.kie.kogito</groupId>
                                 <artifactId>kogito-quarkus-archetype</artifactId>
-                                <version>1.5.0.Final</version>
+                                <version>@version.kogito.quarkus@</version>
                             </archetype>
                             <delete-resources>
                                 <resource>
@@ -107,8 +107,8 @@
                             <id>springboot</id>
                             <archetype>
                                 <groupId>org.kie.kogito</groupId>
-                                <artifactId>kogito-springboot-archetype</artifactId>
-                                <version>1.5.0.Final</version>
+                                <artifactId>kogito-spring-boot-archetype</artifactId>
+                                <version>@version.kogito@</version>
                             </archetype>
                             <delete-resources>
                                 <resource>
@@ -147,7 +147,7 @@
                             <archetype>
                                 <groupId>org.kie</groupId>
                                 <artifactId>kie-kjar-archetype</artifactId>
-                                <version>7.52.0.Final</version>
+                                <version>@version.kie@</version>
                             </archetype>
                             <delete-resources>
                                 <resource>

--- a/kie-assets-plugin/src/it/active-structure-id-it/pom.xml
+++ b/kie-assets-plugin/src/it/active-structure-id-it/pom.xml
@@ -62,7 +62,7 @@
                             <archetype>
                                 <groupId>org.kie.kogito</groupId>
                                 <artifactId>kogito-quarkus-archetype</artifactId>
-                                <version>1.5.0.Final</version>
+                                <version>@version.kogito.quarkus@</version>
                             </archetype>
                             <delete-resources>
                                 <resource>
@@ -107,8 +107,8 @@
                             <id>springboot</id>
                             <archetype>
                                 <groupId>org.kie.kogito</groupId>
-                                <artifactId>kogito-springboot-archetype</artifactId>
-                                <version>1.5.0.Final</version>
+                                <artifactId>kogito-spring-boot-archetype</artifactId>
+                                <version>@version.kogito@</version>
                             </archetype>
                             <delete-resources>
                                 <resource>
@@ -147,7 +147,7 @@
                             <archetype>
                                 <groupId>org.kie</groupId>
                                 <artifactId>kie-kjar-archetype</artifactId>
-                                <version>7.52.0.Final</version>
+                                <version>@version.kie@</version>
                             </archetype>
                             <delete-resources>
                                 <resource>

--- a/kie-assets-plugin/src/it/cartesian-product-it/pom.xml
+++ b/kie-assets-plugin/src/it/cartesian-product-it/pom.xml
@@ -62,7 +62,7 @@
                             <archetype>
                                 <groupId>org.kie.kogito</groupId>
                                 <artifactId>kogito-quarkus-archetype</artifactId>
-                                <version>1.5.0.Final</version>
+                                <version>@version.kogito.quarkus@</version>
                             </archetype>
                             <delete-resources>
                                 <resource>
@@ -108,8 +108,8 @@
                             <id>springboot</id>
                             <archetype>
                                 <groupId>org.kie.kogito</groupId>
-                                <artifactId>kogito-springboot-archetype</artifactId>
-                                <version>1.5.0.Final</version>
+                                <artifactId>kogito-spring-boot-archetype</artifactId>
+                                <version>@version.kogito@</version>
                             </archetype>
                             <delete-resources>
                                 <resource>
@@ -148,7 +148,7 @@
                             <archetype>
                                 <groupId>org.kie</groupId>
                                 <artifactId>kie-kjar-archetype</artifactId>
-                                <version>7.52.0.Final</version>
+                                <version>@version.kie@</version>
                             </archetype>
                             <delete-resources>
                                 <resource>

--- a/pom.xml
+++ b/pom.xml
@@ -23,8 +23,9 @@
 
     <main.basedir>${maven.multiModuleProjectDirectory}</main.basedir>
 
-    <version.kie>7.52.0.Final</version.kie>
-    <version.kogito>1.5.0.Final</version.kogito>
+    <version.kie>7.59.0.Final</version.kie>
+    <version.kogito.quarkus>1.5.0.Final</version.kogito.quarkus>
+    <version.kogito>1.11.1.Final</version.kogito>
     <version.junit>4.12</version.junit>
     <!-- plugin versions -->
     <version.checkstyle.plugin>3.0.0</version.checkstyle.plugin>


### PR DESCRIPTION
… 1.11.1.Final

* So far we have 2 versions, `version.kogito` for Spring Boot and `version.kogito.quarkus` for Quarkus. This is just temporary until we have quarkus-maven-plugin project structure merged.
* I have swapped hardcoded versions of archetypes in integration tests for dynamic properties taken from the parent.
* `kogito-springboot-archetype` is now `kogito-spring-boot-archetype`.