### PR TITLE
add quarkus extensions registry config option

### DIFF
--- a/kie-assets-library-support/pom.xml
+++ b/kie-assets-library-support/pom.xml
@@ -29,6 +29,7 @@
         <quarkus.settings/>
         <springboot.settings/>
         <separateRepository>false</separateRepository>
+        <quarkus.config.file></quarkus.config.file>
     </properties>
 
     <dependencies>
@@ -91,6 +92,31 @@
                                 </configSets>
                             </projectStructure>
                             <projectStructure>
+                                <id>quarkus-mvn-with-registry</id>
+                                <generate>
+                                    <type>MAVEN_PLUGIN</type>
+                                    <mavenPluginConfig>
+                                        <groupId>${quarkus.platform.groupId}</groupId>
+                                        <artifactId>quarkus-maven-plugin</artifactId>
+                                        <version>${version.quarkus.platform}</version>
+                                        <goal>create</goal>
+                                    </mavenPluginConfig>
+                                    <quarkusExtensions>${quarkus.extensions}</quarkusExtensions>
+                                    <quarkusConfigFile>${quarkus.config.file}</quarkusConfigFile>
+                                    <settingsFile>${quarkus.settings}</settingsFile>
+                                    <useSeparateRepository>${separateRepository}</useSeparateRepository>
+                                </generate>
+                                <commonConfig>
+                                    <reusableConfig>clean-main-sources-resources-and-readme</reusableConfig>
+                                </commonConfig>
+                                <configSets>
+                                    <configSet>
+                                        <id>scesim</id>
+                                        <reusableConfig>kogito-scesim</reusableConfig>
+                                    </configSet>
+                                </configSets>
+                            </projectStructure>
+                            <projectStructure>
                                 <id>quarkus-cli</id>
                                 <generate>
                                     <type>QUARKUS_CLI</type>
@@ -100,6 +126,23 @@
                                         <version>${version.quarkus.platform}</version>
                                     </quarkusPlatformGav>
                                     <quarkusExtensions>${quarkus.extensions}</quarkusExtensions>
+                                </generate>
+                                <commonConfig>
+                                    <reusableConfig>clean-main-sources-resources-and-readme</reusableConfig>
+                                </commonConfig>
+                                <configSets>
+                                    <configSet>
+                                        <id>scesim</id>
+                                        <reusableConfig>kogito-scesim</reusableConfig>
+                                    </configSet>
+                                </configSets>
+                            </projectStructure>
+                            <projectStructure>
+                                <id>quarkus-cli-with-registry</id>
+                                <generate>
+                                    <type>QUARKUS_CLI</type>
+                                    <quarkusExtensions>${quarkus.extensions}</quarkusExtensions>
+                                    <quarkusConfigFile>${quarkus.config.file}</quarkusConfigFile>
                                 </generate>
                                 <commonConfig>
                                     <reusableConfig>clean-main-sources-resources-and-readme</reusableConfig>

--- a/kie-assets-plugin/src/main/java/org/kie/model/ProjectGeneration.java
+++ b/kie-assets-plugin/src/main/java/org/kie/model/ProjectGeneration.java
@@ -28,6 +28,7 @@ public class ProjectGeneration {
     private MavenPluginConfig mavenPluginConfig;
     private String quarkusExtensions;
     private Artifact quarkusPlatformGav;
+    private File quarkusConfigFile;
     private File settingsFile;
     private boolean useSeparateRepository;
 
@@ -77,6 +78,14 @@ public class ProjectGeneration {
 
     public void setQuarkusPlatformGav(Artifact quarkusPlatformGav) {
         this.quarkusPlatformGav = quarkusPlatformGav;
+    }
+
+    public File getQuarkusConfigFile() {
+        return quarkusConfigFile;
+    }
+
+    public void setQuarkusConfigFile(File quarkusConfigFile) {
+        this.quarkusConfigFile = quarkusConfigFile;
     }
 
     public File getSettingsFile() {

--- a/kie-assets-plugin/src/main/java/org/kie/mojos/GenerateProjectMojo.java
+++ b/kie-assets-plugin/src/main/java/org/kie/mojos/GenerateProjectMojo.java
@@ -223,6 +223,9 @@ public class GenerateProjectMojo
         if (structure.getGenerate().getQuarkusExtensions() != null && !structure.getGenerate().getQuarkusExtensions().isEmpty()) {
             formatter.format(" -x %s", structure.getGenerate().getQuarkusExtensions());
         }
+        if (structure.getGenerate().getQuarkusConfigFile() != null) {
+            formatter.format(" --config=%s", structure.getGenerate().getQuarkusConfigFile().getAbsolutePath());
+        }
         if (structure.getGenerate().getQuarkusPlatformGav() != null) {
             formatter.format(" --platform-bom %s:%s:%s",
                     structure.getGenerate().getQuarkusPlatformGav().getGroupId(),
@@ -279,6 +282,9 @@ public class GenerateProjectMojo
         determineLocalRepo(structure).ifPresent(file -> formatter.format(" -Dmaven.repo.local=%s", file.getAbsolutePath()));
         if (structure.getGenerate().getQuarkusExtensions() != null && !structure.getGenerate().getQuarkusExtensions().isEmpty()) {
             formatter.format(" -Dextensions=%s", structure.getGenerate().getQuarkusExtensions());
+        }
+        if (structure.getGenerate().getQuarkusConfigFile() != null) {
+            formatter.format(" -Dquarkus.tools.config=%s", structure.getGenerate().getQuarkusConfigFile().getAbsolutePath());
         }
         if (structure.getGenerate().getQuarkusPlatformGav() != null) {
             formatter

--- a/kie-assets-plugin/src/test/java/org/kie/mojos/GenerateProjectCommandTest.java
+++ b/kie-assets-plugin/src/test/java/org/kie/mojos/GenerateProjectCommandTest.java
@@ -65,6 +65,7 @@ public class GenerateProjectCommandTest extends AbstractMojoTest<GenerateProject
                 String.format(" %s:%s", definition.getGroupId(), definition.getArtifactId()),
                 String.format(" --package-name %s", definition.getPackageName()),
                 String.format(" -x %s", structure.getGenerate().getQuarkusExtensions()),
+                String.format(" --config=%s", structure.getGenerate().getQuarkusConfigFile().getAbsolutePath()),
                 String.format(" --platform-bom %s:%s:%s", quarkusPlatformGav.getGroupId(), quarkusPlatformGav.getArtifactId(), quarkusPlatformGav.getVersion())));
     }
 
@@ -80,6 +81,7 @@ public class GenerateProjectCommandTest extends AbstractMojoTest<GenerateProject
                         String.format(" -DprojectArtifactId=%s", definition.getArtifactId()),
                         String.format(" -DpackageName=%s", definition.getPackageName()),
                         String.format(" -Dextensions=%s", structure.getGenerate().getQuarkusExtensions()),
+                        String.format(" -Dquarkus.tools.config=%s", structure.getGenerate().getQuarkusConfigFile().getAbsolutePath()),
                         String.format(" -DplatformGroupId=%s", quarkusPlatformGav.getGroupId()),
                         String.format(" -DplatformArtifactId=%s", quarkusPlatformGav.getArtifactId()),
                         String.format(" -DplatformVersion=%s", quarkusPlatformGav.getVersion())));

--- a/kie-assets-plugin/src/test/resources/generate-project/project-structure-generate.xml
+++ b/kie-assets-plugin/src/test/resources/generate-project/project-structure-generate.xml
@@ -43,6 +43,7 @@
                   <version>quarkus-platform-version</version>
                 </quarkusPlatformGav>
                 <quarkusExtensions>kogito-quarkus-decisions,kogito-quarkus-rules,kogito-quarkus-predictions,kogito-quarkus-processes</quarkusExtensions>
+                <quarkusConfigFile>/tmp/path-to-config-file</quarkusConfigFile>
               </generate>
             </projectStructure>
             <projectStructure>
@@ -55,6 +56,7 @@
                   <version>quarkus-platform-version</version>
                 </quarkusPlatformGav>
                 <quarkusExtensions>kogito-quarkus-decisions,kogito-quarkus-rules,kogito-quarkus-predictions,kogito-quarkus-processes</quarkusExtensions>
+                <quarkusConfigFile>/tmp/path-to-config-file</quarkusConfigFile>
               </generate>
             </projectStructure>
             <projectStructure>


### PR DESCRIPTION
Quarkus Extensions Registry client allows to gather latest metadata based on provided configuration file.
This introduces `quarkus-cli` and `quarkus-mvn` variants to use such dynamic resolution instead of pre-defined platform BOM GAVs.
Example format of configuration file:
```
---
debug: true
registries:
  - registry.quarkus.io:
      enabled: true
      update-policy: "always"
      maven:
        repository:
          url: "http://<url-of-your-quarkus-registry>:8085/maven"
```