### PR TITLE
BAQE-2232 - Make kie-assets-library Quarkus examples compilable with …

### DIFF
--- a/kie-assets-library-assets/src/main/resources/smarthouse/stp/smartHouse.bpmn
+++ b/kie-assets-library-assets/src/main/resources/smarthouse/stp/smartHouse.bpmn
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <bpmn2:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn2="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:drools="http://www.jboss.org/drools" id="_vs4KQAgJEDqWEpL6nhfDjw" xsi:schemaLocation="http://www.omg.org/spec/BPMN/20100524/MODEL BPMN20.xsd http://www.jboss.org/drools drools.xsd http://www.bpsim.org/schemas/1.0 bpsim.xsd http://www.omg.org/spec/DD/20100524/DC DC.xsd http://www.omg.org/spec/DD/20100524/DI DI.xsd " exporter="jBPM Process Modeler" exporterVersion="2.0" targetNamespace="http://www.omg.org/bpmn20">
-  <bpmn2:itemDefinition id="_sensorsTemperatureItem" structureRef="java.util.List&lt;org.kie.smarthouse.SensorInput&gt;"/>
-  <bpmn2:itemDefinition id="_sensorsHumidityItem" structureRef="java.util.List&lt;org.kie.smarthouse.SensorInput&gt;"/>
+  <bpmn2:itemDefinition id="_sensorsTemperatureItem" structureRef="java.util.List"/>
+  <bpmn2:itemDefinition id="_sensorsHumidityItem" structureRef="java.util.List"/>
   <bpmn2:itemDefinition id="_settingsTemperatureItem" structureRef="org.kie.smarthouse.SmartHomeSetting"/>
   <bpmn2:itemDefinition id="_settingsHumidityItem" structureRef="org.kie.smarthouse.SmartHomeSetting"/>
   <bpmn2:itemDefinition id="_shouldCoolingBeOnItem" structureRef="Boolean"/>
@@ -9,10 +10,10 @@
   <bpmn2:itemDefinition id="__4B0C6117-C8DA-4962-A1E1-B2085274150C_namespaceInputXItem" structureRef="java.lang.String"/>
   <bpmn2:itemDefinition id="__4B0C6117-C8DA-4962-A1E1-B2085274150C_modelInputXItem" structureRef="java.lang.String"/>
   <bpmn2:itemDefinition id="__4B0C6117-C8DA-4962-A1E1-B2085274150C_decisionInputXItem" structureRef="java.lang.String"/>
-  <bpmn2:itemDefinition id="__4B0C6117-C8DA-4962-A1E1-B2085274150C_Sensors-HumidityInputXItem" structureRef="java.util.List&lt;org.kie.smarthouse.SensorInput&gt;"/>
+  <bpmn2:itemDefinition id="__4B0C6117-C8DA-4962-A1E1-B2085274150C_Sensors-HumidityInputXItem" structureRef="java.util.List"/>
   <bpmn2:itemDefinition id="__4B0C6117-C8DA-4962-A1E1-B2085274150C_Settings-TemperatureInputXItem" structureRef="org.kie.smarthouse.SmartHomeSetting"/>
   <bpmn2:itemDefinition id="__4B0C6117-C8DA-4962-A1E1-B2085274150C_Settings-HumidityInputXItem" structureRef="org.kie.smarthouse.SmartHomeSetting"/>
-  <bpmn2:itemDefinition id="__4B0C6117-C8DA-4962-A1E1-B2085274150C_Sensors-TemperatureInputXItem" structureRef="java.util.List&lt;org.kie.smarthouse.SensorInput&gt;"/>
+  <bpmn2:itemDefinition id="__4B0C6117-C8DA-4962-A1E1-B2085274150C_Sensors-TemperatureInputXItem" structureRef="java.util.List"/>
   <bpmn2:itemDefinition id="__4B0C6117-C8DA-4962-A1E1-B2085274150C_Should-Cooling-Be-On?OutputXItem" structureRef="Boolean"/>
   <bpmn2:itemDefinition id="__4B0C6117-C8DA-4962-A1E1-B2085274150C_Should-Heater-Be-On?OutputXItem" structureRef="Boolean"/>
   <bpmn2:itemDefinition id="__4B0C6117-C8DA-4962-A1E1-B2085274150C_Should-Windows-Be-Opened?OutputXItem" structureRef="Boolean"/>
@@ -39,10 +40,10 @@
         <bpmn2:dataInput id="_4B0C6117-C8DA-4962-A1E1-B2085274150C_namespaceInputX" drools:dtype="java.lang.String" itemSubjectRef="__4B0C6117-C8DA-4962-A1E1-B2085274150C_namespaceInputXItem" name="namespace"/>
         <bpmn2:dataInput id="_4B0C6117-C8DA-4962-A1E1-B2085274150C_decisionInputX" drools:dtype="java.lang.String" itemSubjectRef="__4B0C6117-C8DA-4962-A1E1-B2085274150C_decisionInputXItem" name="decision"/>
         <bpmn2:dataInput id="_4B0C6117-C8DA-4962-A1E1-B2085274150C_modelInputX" drools:dtype="java.lang.String" itemSubjectRef="__4B0C6117-C8DA-4962-A1E1-B2085274150C_modelInputXItem" name="model"/>
-        <bpmn2:dataInput id="_4B0C6117-C8DA-4962-A1E1-B2085274150C_Sensors-HumidityInputX" drools:dtype="java.util.List&lt;org.kie.smarthouse.SensorInput&gt;" itemSubjectRef="__4B0C6117-C8DA-4962-A1E1-B2085274150C_Sensors-HumidityInputXItem" name="Sensors Humidity"/>
+        <bpmn2:dataInput id="_4B0C6117-C8DA-4962-A1E1-B2085274150C_Sensors-HumidityInputX" drools:dtype="java.util.List" itemSubjectRef="__4B0C6117-C8DA-4962-A1E1-B2085274150C_Sensors-HumidityInputXItem" name="Sensors Humidity"/>
         <bpmn2:dataInput id="_4B0C6117-C8DA-4962-A1E1-B2085274150C_Settings-TemperatureInputX" drools:dtype="org.kie.smarthouse.SmartHomeSetting" itemSubjectRef="__4B0C6117-C8DA-4962-A1E1-B2085274150C_Settings-TemperatureInputXItem" name="Settings Temperature"/>
         <bpmn2:dataInput id="_4B0C6117-C8DA-4962-A1E1-B2085274150C_Settings-HumidityInputX" drools:dtype="org.kie.smarthouse.SmartHomeSetting" itemSubjectRef="__4B0C6117-C8DA-4962-A1E1-B2085274150C_Settings-HumidityInputXItem" name="Settings Humidity"/>
-        <bpmn2:dataInput id="_4B0C6117-C8DA-4962-A1E1-B2085274150C_Sensors-TemperatureInputX" drools:dtype="java.util.List&lt;org.kie.smarthouse.SensorInput&gt;" itemSubjectRef="__4B0C6117-C8DA-4962-A1E1-B2085274150C_Sensors-TemperatureInputXItem" name="Sensors Temperature"/>
+        <bpmn2:dataInput id="_4B0C6117-C8DA-4962-A1E1-B2085274150C_Sensors-TemperatureInputX" drools:dtype="java.util.List" itemSubjectRef="__4B0C6117-C8DA-4962-A1E1-B2085274150C_Sensors-TemperatureInputXItem" name="Sensors Temperature"/>
         <bpmn2:dataOutput id="_4B0C6117-C8DA-4962-A1E1-B2085274150C_Should-Cooling-Be-On?OutputX" drools:dtype="Boolean" itemSubjectRef="__4B0C6117-C8DA-4962-A1E1-B2085274150C_Should-Cooling-Be-On?OutputXItem" name="Should Cooling Be On?"/>
         <bpmn2:dataOutput id="_4B0C6117-C8DA-4962-A1E1-B2085274150C_Should-Heater-Be-On?OutputX" drools:dtype="Boolean" itemSubjectRef="__4B0C6117-C8DA-4962-A1E1-B2085274150C_Should-Heater-Be-On?OutputXItem" name="Should Heater Be On?"/>
         <bpmn2:dataOutput id="_4B0C6117-C8DA-4962-A1E1-B2085274150C_Should-Windows-Be-Opened?OutputX" drools:dtype="Boolean" itemSubjectRef="__4B0C6117-C8DA-4962-A1E1-B2085274150C_Should-Windows-Be-Opened?OutputXItem" name="Should Windows Be Opened?"/>

--- a/kie-assets-library-generate/pom.xml
+++ b/kie-assets-library-generate/pom.xml
@@ -177,21 +177,21 @@
         <profile>
             <id>decisions-capability</id>
             <properties>
-                <quarkus.extensions>kogito-quarkus-decisions</quarkus.extensions>
+                <quarkus.extensions>kogito-quarkus-decisions,quarkus-resteasy,quarkus-resteasy-jackson</quarkus.extensions>
                 <springboot.starters>decisions</springboot.starters>
             </properties>
         </profile>
         <profile>
             <id>prediction-capability</id>
             <properties>
-                <quarkus.extensions>kogito-quarkus-predictions,quarkus-smallrye-health</quarkus.extensions>
+                <quarkus.extensions>kogito-quarkus-predictions,quarkus-smallrye-health,quarkus-resteasy,quarkus-resteasy-jackson</quarkus.extensions>
                 <springboot.starters>predictions</springboot.starters>
             </properties>
         </profile>
         <profile>
             <id>decisions-processes-capability</id>
             <properties>
-                <quarkus.extensions>kogito-quarkus-decisions,kogito-quarkus-processes</quarkus.extensions>
+                <quarkus.extensions>kogito-quarkus-decisions,kogito-quarkus-processes,quarkus-resteasy,quarkus-resteasy-jackson</quarkus.extensions>
                 <springboot.starters>decisions,processes</springboot.starters>
             </properties>
         </profile>

--- a/kie-assets-library-support/pom.xml
+++ b/kie-assets-library-support/pom.xml
@@ -22,7 +22,7 @@
         <support.basedir>${main.basedir}/kie-assets-library-support</support.basedir>
         <quarkus.archetype.artifactId>kogito-quarkus-archetype</quarkus.archetype.artifactId>
         <springboot.archetype.artifactId>kogito-spring-boot-archetype</springboot.archetype.artifactId>
-        <quarkus.extensions>kogito-quarkus-decisions,kogito-quarkus-rules,kogito-quarkus-predictions,kogito-quarkus-processes,quarkus-smallrye-health</quarkus.extensions>
+        <quarkus.extensions>kogito-quarkus-decisions,kogito-quarkus-rules,kogito-quarkus-predictions,kogito-quarkus-processes,quarkus-smallrye-health,quarkus-resteasy,quarkus-resteasy-jackson</quarkus.extensions>
         <springboot.starters>decisions,rules,predictions,processes</springboot.starters>
         <springboot.addons></springboot.addons>
         <!-- By default use the settings.xml and local maven repo from the main build -->


### PR DESCRIPTION
…newest Quarkus Platform

[BAQE-2232](https://issues.redhat.com/browse/BAQE-2232)
@jstastny-cz this should fix issues with #20
@jiripetrlik FYI I included quarkus-resteasy and quarkus-resteasy-jackson in the extensions list. They are no more added by default.